### PR TITLE
Handle noTxPool correctly

### DIFF
--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -190,6 +190,7 @@ func NewDriver(
 		sequencerActive:    make(chan chan bool, 10),
 		sequencerNotifs:    sequencerStateListener,
 		config:             cfg,
+		spec:               rollup.NewChainSpec(cfg),
 		syncCfg:            syncCfg,
 		driverConfig:       driverCfg,
 		driverCtx:          driverCtx,

--- a/op-node/rollup/driver/state.go
+++ b/op-node/rollup/driver/state.go
@@ -494,23 +494,7 @@ func (d *Driver) PublishL2Attributes(ctx context.Context, l2head eth.L2BlockRef)
 		return err
 	}
 
-	// If our next L2 block timestamp is beyond the Sequencer drift threshold, then we must produce
-	// empty blocks (other than the L1 info deposit and any user deposits). We handle this by
-	// setting NoTxPool to true, which will cause the Sequencer to not include any transactions
-	// from the transaction pool.
-	attrs.NoTxPool = uint64(attrs.Timestamp) > l1Origin.Time+d.spec.MaxSequencerDrift(l1Origin.Time)
-
-	// For the Ecotone activation block we shouldn't include any sequencer transactions.
-	if d.config.IsEcotoneActivationBlock(uint64(attrs.Timestamp)) {
-		attrs.NoTxPool = true
-		d.log.Info("Sequencing Ecotone upgrade block")
-	}
-
-	// For the Fjord activation block we shouldn't include any sequencer transactions.
-	if d.config.IsFjordActivationBlock(uint64(attrs.Timestamp)) {
-		attrs.NoTxPool = true
-		d.log.Info("Sequencing Fjord upgrade block")
-	}
+	derive.SetNoTxPool(d.config, d.spec, attrs, l1Origin, l2head)
 
 	d.log.Debug("prepared attributes for new block",
 		"num", l2head.Number+1, "time", uint64(attrs.Timestamp),


### PR DESCRIPTION
- noTxPool is handled by the caller, of which there are two: CLSync and Driver.
- noTxPool should be handled in case when there is a specific request from sequencer where there needs to be a upgrade tx that sets noTxPool to perform chain upgrade.